### PR TITLE
decoder: ensure user data parsing module doesn't read beyond the buffer

### DIFF
--- a/decoder/impeg2d_dec_hdr.c
+++ b/decoder/impeg2d_dec_hdr.c
@@ -1598,7 +1598,8 @@ void impeg2d_dec_user_data(dec_state_t *ps_dec)
     ps_stream    = &ps_dec->s_bit_stream;
     u4_start_code = impeg2d_bit_stream_nxt(ps_stream,START_CODE_LEN);
 
-    while(u4_start_code == USER_DATA_START_CODE)
+    while((u4_start_code == USER_DATA_START_CODE) &&
+        (ps_stream->u4_offset <= ps_stream->u4_max_offset))
     {
         impeg2d_bit_stream_flush(ps_stream,START_CODE_LEN);
         while((impeg2d_bit_stream_nxt(ps_stream,START_CODE_PREFIX_LEN) != START_CODE_PREFIX) &&


### PR DESCRIPTION
Bug: oss-fuzz:22510
Test: mpeg2_dec_fuzzer