### PR TITLE
decoder: add "summary" in the codec_exit error message

### DIFF
--- a/test/decoder/main.c
+++ b/test/decoder/main.c
@@ -866,6 +866,7 @@ IV_API_CALL_STATUS_T get_version(void *codec_obj)
 /*****************************************************************************/
 void codec_exit(CHAR *pc_err_message)
 {
+    printf("Summary\n");
     printf("%s\n", pc_err_message);
     exit(-1);
 }


### PR DESCRIPTION
Test: mpeg2dec