### PR TITLE
Fix error handling in impeg2d_dec_pic_data_thread

### DIFF
--- a/decoder/impeg2d_dec_hdr.c
+++ b/decoder/impeg2d_dec_hdr.c
@@ -1041,12 +1041,8 @@ void impeg2d_dec_pic_data_thread(dec_state_t *ps_dec)
 
             if ((IMPEG2D_ERROR_CODES_T)IVD_ERROR_NONE != e_error)
             {
-                impeg2d_next_start_code(ps_dec);
-                if(ps_dec->s_bit_stream.u4_offset >= ps_dec->s_bit_stream.u4_max_offset)
-                {
-                    ps_dec->u4_error_code = IMPEG2D_BITSTREAM_BUFF_EXCEEDED_ERR;
-                    return;
-                }
+                ps_dec->u2_num_mbs_left = 0;
+                break;
             }
 
             /* Detecting next slice start code */


### PR DESCRIPTION
In case of errors in impeg2d_dec_pic_data_thread() instead of returning, 
the function is now updated to break the processing loop and consider 
all the MBs in the row as skipped.

Test: mpeg2_dec_fuzzer