### PR TITLE
decoder: increase intermediate bitstream buffer size

### DIFF
--- a/decoder/impeg2d_structs.h
+++ b/decoder/impeg2d_structs.h
@@ -39,7 +39,7 @@ Because of temporal dependency in deinterlacer one additional buffer is also nee
 
 #define DEC_ORDER               0
 
-#define MAX_BITSTREAM_BUFFER_SIZE       2000 * 1024
+#define MAX_BITSTREAM_BUFFER_SIZE       (MAX_WIDTH * MAX_HEIGHT * 3 / 2)
 #define MIN_BUFFER_BYTES_AT_EOS 8
 
 /* Flag to signal that buffer is held by deinterlacing */


### PR DESCRIPTION
Earlier, the size for the intermediate bitstream buffer was hard-coded creating the possibility of buffer overflows in case of large data. This has been resolved by defining this buffer size' based on max height and max width.

Bug: oss-fuzz:56898
Bug: 273291708
Test: mpeg2_dec_fuzzer
(cherry picked from https://partner-android-review.googlesource.com/q/commit:3a10c1f25185b5427e478454d73ded7b3bcac94a) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:3cb820f35397cd9ebfd49030004994a63e48f59b) Merged-In: Ifc8cbbdf46ced7dc1586798be111ef6729d0d808 Change-Id: Ifc8cbbdf46ced7dc1586798be111ef6729d0d808