### PR TITLE
libmpeg2: remove unused KEEP_THREADS_ACTIVE flag in Android.bp

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -32,8 +32,6 @@ cc_library_static {
         "-O3",
         "-DANDROID",
         "-Werror",
-        // #KEEP_THREAD_ACTIVE is experimental
-        "-UKEEP_THREADS_ACTIVE",
     ],
 
     export_include_dirs: [


### PR DESCRIPTION
Bug: 376303949
Test: Build and review